### PR TITLE
Daylight saving fix: The default dart DateTime object caused incorrect week startday data.

### DIFF
--- a/lib/calendar_strip.dart
+++ b/lib/calendar_strip.dart
@@ -46,7 +46,8 @@ class CalendarStrip extends StatefulWidget {
 
 class CalendarStripState extends State<CalendarStrip>
     with TickerProviderStateMixin {
-  DateTime currentDate = DateTime.now();
+  DateTime currentDate = DateTime.utc(
+      DateTime.now().year, DateTime.now().month, DateTime.now().day);
   DateTime selectedDate;
   String monthLabel;
   bool inBetweenMonths = false;
@@ -184,7 +185,7 @@ class CalendarStripState extends State<CalendarStrip>
   }
 
   DateTime getDateOnly(DateTime dateTimeObj) {
-    return DateTime(dateTimeObj.year, dateTimeObj.month, dateTimeObj.day);
+    return DateTime.utc(dateTimeObj.year, dateTimeObj.month, dateTimeObj.day);
   }
 
   bool isDateMarked(date) {


### PR DESCRIPTION
The DateTime object automatically accounts for daylight savings and by doing so,
returned incorrect dates. For example if I would go from the week of
19 okt 2020 to the week of 26 okt 2020 it would display the week starting
at sunday 25 okt. 25 okt 2020 23:00 to be exact. DateTime.utc() does not
account for daylight savings so I just had to swap some default
constructors with UTC constructors.